### PR TITLE
Bump dlist upper bound to 0.9

### DIFF
--- a/list-tries.cabal
+++ b/list-tries.cabal
@@ -43,7 +43,7 @@ source-repository head
 Library
    Build-Depends: base       >= 3    && < 4.10
                 , containers >= 0.3  && < 0.6
-                , dlist      >= 0.4  && < 0.8
+                , dlist      >= 0.4  && < 0.9
                 , binary     >= 0.5  && < 0.9
 
    if impl(ghc < 8.0)


### PR DESCRIPTION
I just released [`dlist-0.8`](https://github.com/spl/dlist/releases/tag/v0.8). I didn't test this change to `list-tries`, but I don't think it will be break anything.