### PR TITLE
.travis.yml: Allow ghc-head failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ matrix:
       compiler: ": #GHC HEAD"
       addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}
 
+  allow_failures:
+    - compiler: ": #GHC HEAD"
 
 before_install:
  - unset CC


### PR DESCRIPTION
IMO it's absolutely normal for this configuration to be red from time to time (or even most of the time).